### PR TITLE
42-coin-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-42 - a fork of Litecoin version with fast block time and faster confirmations (2 confirmations needed instead of 6). Like Litecoin it uses scrypt as a proof of work scheme.
+42-limited-edition - a fork of Litecoin version with fast block time and faster confirmations (2 confirmations needed instead of 6). Like Litecoin it uses scrypt as a proof of work scheme.
 
 	- 42 second block target
 	- Difficulty retargets every 7 minutes
-	- Total coins will be only 42
+	- Total coins will be only 42  --   this time for real yo!
 	- The default ports are 24242 (connect) and 4242 (json rpc).
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -863,6 +863,10 @@ int64 static GetBlockValue(int nHeight, int64 nFees)
     {
        nSubsidy = 0.00042 * COIN;
 	}
+    if(nHeight >= 990382)  
+    {  
+       nSubsidy = 0.00;
+	}
     return nSubsidy + nFees;
 }
 


### PR DESCRIPTION
Added one line to admit only fees after block 990382.  This keeps total coins in circulation at EXACTLY 42 LIKE THE NAME OF THE COIN.  Pretty simple.  
